### PR TITLE
Enable termination of infinite event generators

### DIFF
--- a/aurora_hal/aurora_hal_macros/src/expression_parser.lalrpop
+++ b/aurora_hal/aurora_hal_macros/src/expression_parser.lalrpop
@@ -228,4 +228,3 @@ Num: String = {
     "true" => <>.to_string(),
     "false" => <>.to_string(),
 };
-

--- a/event_gen/src/event_generator.rs
+++ b/event_gen/src/event_generator.rs
@@ -1,7 +1,11 @@
 use std::marker::Send;
 use std::sync::mpsc::Sender;
-use std::thread::JoinHandle;
 
 pub trait EventGenerator<T: Send, U> {
-    fn start(self, send_handle: Sender<T>) -> JoinHandle<U>;
+    type Handle: EventGenHandle;
+    fn start(self, send_handle: Sender<T>) -> Self::Handle;
+}
+
+pub trait EventGenHandle {
+    fn stop(self);
 }

--- a/event_gen/src/event_generator.rs
+++ b/event_gen/src/event_generator.rs
@@ -7,11 +7,11 @@ pub trait EventGenerator<T: Send, U> {
 }
 
 pub trait EventGenHandle {
-    fn stop(self);
+    fn stop(&mut self);
 }
 
 impl EventGenHandle for () {
-    fn stop(self) {
+    fn stop(&mut self) {
         // Do nothing.
     }
 }

--- a/event_gen/src/event_generator.rs
+++ b/event_gen/src/event_generator.rs
@@ -9,3 +9,9 @@ pub trait EventGenerator<T: Send, U> {
 pub trait EventGenHandle {
     fn stop(self);
 }
+
+impl EventGenHandle for () {
+    fn stop(self) {
+        // Do nothing.
+    }
+}

--- a/event_gen/src/generators/one_shot_generator.rs
+++ b/event_gen/src/generators/one_shot_generator.rs
@@ -1,4 +1,4 @@
-use crate::event_generator::{EventGenHandle, EventGenerator};
+use crate::event_generator::EventGenerator;
 
 use std::marker::Send;
 use std::sync::mpsc::Sender;
@@ -8,22 +8,12 @@ pub struct OneShotGenerator<T: Send> {
     pub value: T,
 }
 
-pub struct OneShotHandle {}
-
-impl EventGenHandle for OneShotHandle {
-    fn stop(self) {
-        // Empty, nothing to do as a one shot will exit immediately
-    }
-}
-
 impl<T: 'static + std::marker::Send> EventGenerator<T, ()> for OneShotGenerator<T> {
-    type Handle = OneShotHandle;
+    type Handle = ();
     fn start(self, send_handle: Sender<T>) -> Self::Handle {
         thread::spawn(move || {
             send_handle.send(self.value).unwrap();
         });
-
-        OneShotHandle {}
     }
 }
 

--- a/event_gen/src/generators/one_shot_generator.rs
+++ b/event_gen/src/generators/one_shot_generator.rs
@@ -1,4 +1,4 @@
-use crate::event_generator::EventGenerator;
+use crate::event_generator::{EventGenHandle, EventGenerator};
 
 use std::marker::Send;
 use std::sync::mpsc::Sender;
@@ -8,11 +8,22 @@ pub struct OneShotGenerator<T: Send> {
     pub value: T,
 }
 
+pub struct OneShotHandle {}
+
+impl EventGenHandle for OneShotHandle {
+    fn stop(self) {
+        // Empty, nothing to do as a one shot will exit immediately
+    }
+}
+
 impl<T: 'static + std::marker::Send> EventGenerator<T, ()> for OneShotGenerator<T> {
-    fn start(self, send_handle: Sender<T>) -> thread::JoinHandle<()> {
+    type Handle = OneShotHandle;
+    fn start(self, send_handle: Sender<T>) -> Self::Handle {
         thread::spawn(move || {
             send_handle.send(self.value).unwrap();
-        })
+        });
+
+        OneShotHandle {}
     }
 }
 

--- a/event_gen/src/generators/tick_generator.rs
+++ b/event_gen/src/generators/tick_generator.rs
@@ -130,7 +130,7 @@ mod tests {
             event_producer: |_now, _prev| 42,
         };
 
-        let handle = tick_gen.start(s);
+        let mut handle = tick_gen.start(s);
         handle.stop();
 
         let stop_time = Instant::now();

--- a/event_gen/src/generators/tick_generator.rs
+++ b/event_gen/src/generators/tick_generator.rs
@@ -1,7 +1,9 @@
-use crate::event_generator::EventGenerator;
+use crate::event_generator::{EventGenHandle, EventGenerator};
 
 use std::marker::Send;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -10,18 +12,39 @@ pub struct TickGenerator<T: Send> {
     pub event_producer: fn(Instant, Instant) -> T,
 }
 
+pub struct TickGenHandle {
+    join_handle: thread::JoinHandle<()>,
+    stop_flag: Arc<AtomicBool>,
+}
+
+impl EventGenHandle for TickGenHandle {
+    fn stop(self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        self.join_handle.join().unwrap();
+    }
+}
+
 impl<T: 'static + Send> EventGenerator<T, ()> for TickGenerator<T> {
-    fn start(self, send_handle: Sender<T>) -> thread::JoinHandle<()> {
-        thread::spawn(move || {
+    type Handle = TickGenHandle;
+    fn start(self, send_handle: Sender<T>) -> Self::Handle {
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag_2 = stop_flag.clone();
+
+        let join_handle = thread::spawn(move || {
             let mut last_time = Instant::now();
-            loop {
+            while !stop_flag_2.load(Ordering::Relaxed) {
                 thread::sleep(self.min_duration);
                 send_handle
                     .send((self.event_producer)(Instant::now(), last_time))
                     .unwrap();
                 last_time = Instant::now();
             }
-        })
+        });
+
+        Self::Handle {
+            join_handle,
+            stop_flag,
+        }
     }
 }
 
@@ -92,5 +115,33 @@ mod tests {
                 acceptable_error
             );
         }
+    }
+
+    #[test]
+    fn does_stop() {
+        let (s, r) = mpsc::channel::<i32>();
+
+        let tick_gen = TickGenerator {
+            min_duration: Duration::from_millis(1),
+            event_producer: |_now, _prev| 42,
+        };
+
+        let handle = tick_gen.start(s);
+        handle.stop();
+
+        let stop_time = Instant::now();
+        while Instant::now() - stop_time < Duration::from_millis(500) {
+            if let Err(_) = r.recv() {
+                // We have stopped receiving events
+                assert!(
+                    true,
+                    "Stopped successfully after {:?}",
+                    Instant::now() - stop_time
+                );
+                return;
+            }
+        }
+
+        assert!(false, "Failed to stop within 500 ms");
     }
 }


### PR DESCRIPTION
This change wraps the return value of the start() function of an event generator in an associated EventGenHandle type. This handle type must enable stopping the event generator (which is currently only relevant for the TickGenerator).