### PR TITLE
Implement per state event types in FSM

### DIFF
--- a/aurora_fsm/src/state.rs
+++ b/aurora_fsm/src/state.rs
@@ -1,9 +1,50 @@
-use std::sync::mpsc::Receiver;
+use std::any::Any;
+use std::sync::mpsc::{Receiver, RecvError};
 
-pub trait State<E> {
-    fn handle_event(&mut self, event: E) -> Option<Box<dyn State<E>>>;
+pub trait State: UntypedState {
+    type Event;
+    fn handle_event(&mut self, event: Self::Event) -> Option<Box<dyn UntypedState>>;
 
-    fn create_event_sources(&mut self) -> Receiver<E>;
+    fn create_event_sources(&mut self) -> Receiver<Self::Event>;
 
     fn destroy_event_sources(&mut self);
+}
+
+pub trait UntypedState {
+    fn handle_untyped(&mut self, event: Box<dyn Any>) -> Option<Box<dyn UntypedState>>;
+
+    fn create_untyped_sources(&mut self) -> Box<dyn ReceiveAny>;
+
+    fn destroy_untyped_sources(&mut self);
+}
+
+impl<T, E: 'static> UntypedState for T
+    where
+        T: State<Event=E>,
+{
+    fn handle_untyped(&mut self, event: Box<dyn Any>) -> Option<Box<dyn UntypedState>> {
+        self.handle_event(
+            *event
+                .downcast::<E>()
+                .expect("Event type mismatch. This is an implementation error, please report it."),
+        )
+    }
+
+    fn create_untyped_sources(&mut self) -> Box<dyn ReceiveAny> {
+        Box::new(self.create_event_sources())
+    }
+
+    fn destroy_untyped_sources(&mut self) {
+        self.destroy_event_sources();
+    }
+}
+
+pub trait ReceiveAny {
+    fn recv_any(&mut self) -> Result<Box<dyn Any>, RecvError>;
+}
+
+impl<T: 'static> ReceiveAny for Receiver<T> {
+    fn recv_any(&mut self) -> Result<Box<dyn Any>, RecvError> {
+        self.recv().map(|x| Box::new(x) as Box<dyn Any>)
+    }
 }

--- a/aurora_fsm/src/state_machine.rs
+++ b/aurora_fsm/src/state_machine.rs
@@ -1,28 +1,31 @@
-use crate::state::State;
-use std::sync::mpsc::Receiver;
+use crate::state::{ReceiveAny, UntypedState};
 
-pub struct StateMachine<E> {
-    current_state: Box<dyn State<E>>,
-    event_queue: Receiver<E>,
+pub struct StateMachine {
+    current_state: Box<dyn UntypedState>,
+    event_queue: Box<dyn ReceiveAny>,
 }
 
-impl<E> StateMachine<E> {
-    pub fn new(initial_state: impl State<E> + 'static) -> Self {
-        let mut boxed = Box::new(initial_state);
-        let queue = boxed.create_event_sources();
+impl StateMachine {
+
+    pub fn new(mut initial_state: impl UntypedState + 'static) -> Self {
+        let event_queue = initial_state.create_untyped_sources();
         Self {
-            current_state: boxed,
-            event_queue: queue,
+            current_state: Box::new(initial_state),
+            event_queue,
         }
     }
 
+    pub fn current_state(&self) -> &Box<dyn UntypedState> {
+        &self.current_state
+    }
+
     pub fn step(&mut self) {
-        match self.event_queue.recv() {
+        match self.event_queue.recv_any() {
             Ok(event) => {
-                if let Some(mut next_state) = self.current_state.handle_event(event) {
-                    self.current_state.destroy_event_sources();
-                    self.event_queue = next_state.create_event_sources();
+                if let Some(next_state) = self.current_state.handle_untyped(event) {
+                    self.current_state.destroy_untyped_sources();
                     self.current_state = next_state;
+                    self.event_queue = self.current_state.create_untyped_sources();
                 }
             }
             Err(_recv_err) => {

--- a/aurora_fsm/tests/basic_fsm.rs
+++ b/aurora_fsm/tests/basic_fsm.rs
@@ -1,123 +1,116 @@
-use aurora_fsm::state::State;
+use aurora_fsm::state::{State, UntypedState};
 use aurora_fsm::state_machine::StateMachine;
-use event_gen::event_generator::EventGenerator;
-use event_gen::generators::one_shot_generator::OneShotGenerator;
-use std::borrow::{Borrow, BorrowMut};
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::mpsc;
 use std::sync::mpsc::Receiver;
+use std::thread;
 
-#[non_exhaustive]
-#[derive(Debug)]
-enum Event {
-    OneShot,
+enum EventsA {
+    GotoB,
+    StayLoopState,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-enum StateIdent {
-    AInit,
-    BInit,
-    BRun,
+struct LoopState {
+    rounds: u32,
 }
 
-struct AState {
-    state_ident: Rc<RefCell<StateIdent>>,
-}
+impl State for LoopState {
+    type Event = EventsA;
 
-impl AState {
-    fn new(state_ident: Rc<RefCell<StateIdent>>) -> Self {
-        Self { state_ident }
-    }
-}
-
-impl State<Event> for AState {
-    fn handle_event(&mut self, event: Event) -> Option<Box<dyn State<Event>>> {
+    fn handle_event(&mut self, event: Self::Event) -> Option<Box<dyn UntypedState>> {
         match event {
-            _ => Some(Box::new(BState {
-                state_ident: Rc::clone(&self.state_ident),
-            })),
+            EventsA::GotoB => Some(Box::new(BState)),
+            EventsA::StayLoopState => None
         }
     }
 
-    fn create_event_sources(&mut self) -> Receiver<Event> {
-        let (sender, receiver) = std::sync::mpsc::channel();
-
-        let one_shot = OneShotGenerator {
-            value: Event::OneShot,
-        };
-        one_shot.start(sender);
-
-        return receiver;
+    fn create_event_sources(&mut self) -> Receiver<Self::Event> {
+        let (tx, rx) = mpsc::channel();
+        let rounds = self.rounds;
+        thread::spawn(move || {
+            for _ in 0..rounds {
+                tx.send(EventsA::StayLoopState).unwrap();
+            }
+            tx.send(EventsA::GotoB).unwrap();
+        });
+        rx
     }
 
-    fn destroy_event_sources(&mut self) {
-        // Empty
-    }
+    fn destroy_event_sources(&mut self) {}
 }
 
-struct BState {
-    state_ident: Rc<RefCell<StateIdent>>,
+enum EventsB {
+    GotoInvalid,
 }
 
-impl State<Event> for BState {
-    fn handle_event(&mut self, event: Event) -> Option<Box<dyn State<Event>>> {
+struct BState;
+
+impl State for BState {
+    type Event = EventsB;
+
+    fn handle_event(&mut self, event: Self::Event) -> Option<Box<dyn UntypedState>> {
         match event {
-            _ => {
-                self.state_ident.borrow_mut().replace(StateIdent::BRun);
-                None
+            EventsB::GotoInvalid => {
+                panic!("State transition into invalid state");
             }
         }
     }
 
-    fn create_event_sources(&mut self) -> Receiver<Event> {
-        self.state_ident.borrow_mut().replace(StateIdent::BInit);
-
-        let (sender, receiver) = std::sync::mpsc::channel();
-
-        let one_shot = OneShotGenerator {
-            value: Event::OneShot,
-        };
-        one_shot.start(sender);
-
-        return receiver;
+    fn create_event_sources(&mut self) -> Receiver<Self::Event> {
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            tx.send(EventsB::GotoInvalid).unwrap();
+        });
+        rx
     }
 
-    fn destroy_event_sources(&mut self) {
-        // Empty
-    }
-}
-
-#[test]
-fn run_basic_fsm() {
-    let state_ident = Rc::new(RefCell::new(StateIdent::AInit));
-    let mut fsm = StateMachine::new(AState::new(state_ident.clone()));
-
-    assert_eq!(
-        *(RefCell::borrow(Rc::borrow(&state_ident))),
-        StateIdent::AInit
-    );
-
-    fsm.step(); // Enter BState
-
-    assert_eq!(
-        *(RefCell::borrow(Rc::borrow(&state_ident))),
-        StateIdent::BInit
-    );
-
-    fsm.step(); // Do step inside BState
-
-    assert_eq!(
-        *(RefCell::borrow(Rc::borrow(&state_ident))),
-        StateIdent::BRun
-    );
+    fn destroy_event_sources(&mut self) {}
 }
 
 #[test]
 #[should_panic]
-fn run_basic_fsm_into_invalid_state() {
-    let state_ident = Rc::new(RefCell::new(StateIdent::AInit));
-    let mut fsm = StateMachine::new(AState::new(state_ident.clone()));
-    fsm.step(); // Enter BState
-    fsm.step(); // Do step inside BState
-    fsm.step(); // Do another step after the only event generator from BState has been exhausted
+fn test_basic_fsm_1() {
+    let mut sm = StateMachine::new(LoopState { rounds: 0 });
+
+    sm.step(); // 0 rounds, therefore goto B
+    sm.step(); // goto invalid
+}
+
+#[test]
+fn test_basic_fsm_2() {
+    let mut sm = StateMachine::new(LoopState { rounds: 100 });
+    for _ in 0..100 {
+        sm.step(); // stay in LoopState
+    }
+    sm.step(); // goto B
+}
+
+#[test]
+#[should_panic]
+fn test_basic_fsm_3() {
+    let mut sm = StateMachine::new(LoopState { rounds: 100 });
+    for _ in 0..100 {
+        sm.step(); // stay in LoopState
+    }
+    sm.step(); // goto B
+    sm.step(); // goto invalid
+}
+
+#[test]
+fn test_large_fsm() {
+    let mut sm = StateMachine::new(LoopState { rounds: 1_000_000 });
+    for _ in 0..1_000_000 {
+        sm.step(); // stay in LoopState
+    }
+    sm.step(); // goto B
+}
+
+#[test]
+#[should_panic]
+fn test_large_fsm_panics() {
+    let mut sm = StateMachine::new(LoopState { rounds: 1_000_000 });
+    for _ in 0..1_000_000 {
+        sm.step(); // stay in LoopState
+    }
+    sm.step(); // goto B
+    sm.step(); // goto invalid
 }


### PR DESCRIPTION
With this PR, event types are defined per state instead of globally for the FSM, as has been previously suggested.

We should experiment a bit and see if this is actually a sensible approach though, compared to idiomatic rust using enums or a global event type.